### PR TITLE
Redirect bootcamp to Kubernetes.io content

### DIFF
--- a/1-0.html
+++ b/1-0.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121828958">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121828958" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -186,7 +189,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -242,7 +245,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -284,7 +287,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-<a class="scrolltop" href="#top"></a>	
+<a class="scrolltop" href="#top"></a>
 
 </div>
 

--- a/1-1.html
+++ b/1-1.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121828969">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121828969" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -185,7 +188,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -214,7 +217,7 @@
 		<div class="row">
 			<div class="col-md-8">
 				<p>
-				<b>Kubernetes coordinates a highly available cluster of computers that are connected to work as a single unit.</b> The abstractions in Kubernetes allow you to deploy containerized applications to a cluster without tying them specifically to individual machines. To make use of this new model of deployment, applications need to be packaged in a way that decouples them from individual hosts: they need to be containerized. Containerized applications are more flexible and available than in past deployment models, where applications were installed directly onto specific machines as packages deeply integrated into the host. <b>Kubernetes automates the distribution and scheduling of application containers across a cluster in a more efficient way.</b> Kubernetes is an <a href="https://github.com/kubernetes/kubernetes">open-source</a> platform and is production-ready. 
+				<b>Kubernetes coordinates a highly available cluster of computers that are connected to work as a single unit.</b> The abstractions in Kubernetes allow you to deploy containerized applications to a cluster without tying them specifically to individual machines. To make use of this new model of deployment, applications need to be packaged in a way that decouples them from individual hosts: they need to be containerized. Containerized applications are more flexible and available than in past deployment models, where applications were installed directly onto specific machines as packages deeply integrated into the host. <b>Kubernetes automates the distribution and scheduling of application containers across a cluster in a more efficient way.</b> Kubernetes is an <a href="https://github.com/kubernetes/kubernetes">open-source</a> platform and is production-ready.
 				</p>
 				<p>A Kubernetes cluster consists of two types of resources:
 					<ul>
@@ -258,7 +261,7 @@
 			<div class="col-md-8">
 				<p><b>The Master is responsible for managing the cluster.</b> The master coordinates all activity in your cluster, such as scheduling applications, maintaining applications' desired state, scaling applications, and rolling out new updates.</p>
 				<p><b>A node is a VM or a physical computer that serves as a worker machine in a Kubernetes cluster.</b> Each node has a Kubelet, which is an agent for managing the node and communicating with the Kubernetes master. The node should also have tools for handling container operations, such as Docker or rkt. A Kubernetes cluster that handles production traffic should have a minimum of three nodes.</p>
-				
+
 			</div>
 			<div class="col-md-4">
 				<div class="content__box content__box_fill">
@@ -270,11 +273,11 @@
 		<div class="row">
 			<div class="col-md-8">
 				<p>When you deploy applications on Kubernetes, you tell the master to start the application containers. The master schedules the containers to run on the cluster's nodes. <b>The nodes communicate with the master using the Kubernetes API</b>, which the master exposes. End users can also use the Kubernetes API directly to interact with the cluster.</p>
-			
+
 				<p>A Kubernetes cluster can be deployed on either physical or virtual machines. To get started with Kubernetes development, you can use <a href="https://github.com/kubernetes/minikube">minikube</a>.  Minikube is a lightweight Kubernetes implmentation that creates a VM on your local machine and deploys a simple cluster containing only one node. Minikube is available for Linux, Mac OS  and Windows systems. The minikube CLI provides basic bootstrapping operations for working with your cluster, including start, stop, status, and delete. For this bootcamp, however, you'll use a provided online terminal with minikube pre-installed.</p>
 
 				<p>Now that you know what Kubernetes is, let’s go to the online tutorial and start our first cluster!</p>
-				
+
 			</div>
 		</div>
 		<br>
@@ -290,7 +293,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -332,7 +335,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/1-2.html
+++ b/1-2.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121828992">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121828992" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -45,7 +46,7 @@
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
 	<script src="https://katacoda.com/embed.js"></script>
-	
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -225,7 +228,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -267,7 +270,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/1-3-1.html
+++ b/1-3-1.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121829007">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121829007" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -185,7 +188,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -216,7 +219,7 @@
 
                 <div id="quizTest1"></div>
 
-				
+
 			</div>
 			<div class="col-md-1"></div>
 		</div>
@@ -235,7 +238,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -277,7 +280,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/1-3-2.html
+++ b/1-3-2.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1469803628265">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1469803628265" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
 	<script src="./public/js/common.js"></script>
@@ -56,7 +57,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -184,7 +187,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -210,7 +213,7 @@
 		<br>
 		<br>
 		<h2 class="title-light">Congratulations!</h2>
-		
+
 		<p style="color: #3771e3;"><i><big>You’ve completed Module 1 of the Bootcamp</big></i></p>
 
 		<br>
@@ -254,7 +257,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -296,7 +299,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/1-3.html
+++ b/1-3.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121829034">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121829034" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -185,7 +188,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -227,7 +230,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -269,7 +272,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/2-0.html
+++ b/2-0.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1469803628195">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1469803628195" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
 	<script src="./public/js/common.js"></script>
@@ -56,7 +57,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -184,7 +187,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -238,7 +241,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -280,7 +283,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/2-1.html
+++ b/2-1.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121828969">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121828969" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -185,7 +188,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -199,7 +202,7 @@
 				</ol>
 			</div>
 		</div>
-		
+
 		<h1>Your first application deployment</h1>
 
 		<div class="row">
@@ -221,8 +224,8 @@
 
 				<p>In a pre-orchestration world, installation scripts would often be used to start applications, but they did not allow recovery from machine failure.  By both creating your application instances and keeping them running across Nodes, Kubernetes Deployments provide a fundamentally different approach to application management. </p>
 
-				
-				
+
+
 			</div>
 
 			<div class="col-md-4">
@@ -262,9 +265,9 @@
 
 				<p>When you create a Deployment, you'll need to specify the container image for your application and the number of replicas that you want to run. You can change that information later by updating your Deployment; Modules <a href="5-0.html">5</a> and <a href="5-0.html">6</a> of the bootcamp discuss how you can update your Deployments.</p>
 
-				
 
-				
+
+
 			</div>
 			<div class="col-md-4">
 				<div class="content__box content__box_fill">
@@ -276,9 +279,9 @@
 		<div class="row">
 			<div class="col-md-8">
 				<p>For our first Deployment, we’ll use a <a href="https://nodejs.org">NodeJS</a> application packaged in a Docker container. The source code and the Dockerfile are available in the <a href="https://github.com/kubernetes/kubernetes-bootcamp">GitHub respository</a> for the Kubernetes Bootcamp.</p>
-				
+
 				<p>Now that you know what Deployments are, let’s go to the online tutorial and deploy our first app!</p>
-			
+
 			</div>
 		</div>
 		<br>
@@ -294,7 +297,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -336,7 +339,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/2-2.html
+++ b/2-2.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121828992">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121828992" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -45,7 +46,7 @@
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
 	<script src="https://katacoda.com/embed.js"></script>
-	
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -226,7 +229,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -268,7 +271,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/2-3-1.html
+++ b/2-3-1.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121829007">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121829007" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -185,7 +188,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -216,7 +219,7 @@
 
                 <div id="quizTest2"></div>
 
-				
+
 			</div>
 			<div class="col-md-1"></div>
 		</div>
@@ -235,7 +238,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -277,7 +280,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/2-3-2.html
+++ b/2-3-2.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1469803628265">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1469803628265" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
 	<script src="./public/js/common.js"></script>
@@ -56,7 +57,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -184,7 +187,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -210,7 +213,7 @@
 		<br>
 		<br>
 		<h2 class="title-light">Congratulations!</h2>
-		
+
 		<p style="color: #3771e3;"><i><big>You’ve completed Module 2 of the Bootcamp</big></i></p>
 
 		<br>
@@ -254,7 +257,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -296,7 +299,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/2-3.html
+++ b/2-3.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121829034">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121829034" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -185,7 +188,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -228,7 +231,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -270,7 +273,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/3-0.html
+++ b/3-0.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1469803628195">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1469803628195" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
 	<script src="./public/js/common.js"></script>
@@ -56,7 +57,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -184,7 +187,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -239,7 +242,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -281,7 +284,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/3-1.html
+++ b/3-1.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121828969">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121828969" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -185,7 +188,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -219,11 +222,11 @@
 					<li>Shared storage, as Volumes</li>
 					<li>Networking, as a unique cluster IP address</li>
 					<li>Information about how to run each container, such as the container image version or specific ports to use</li>
-				</ul> 
+				</ul>
 				<p>A Pod models an application-specific “logical host” and can contain different application containers which are relatively tightly coupled. For example, a Pod might include both the container with your NodeJS app as well as a different container that feeds the data to be published by the NodeJS webserver. The containers in a Pod share an IP Address and port space, are always co-located and co-scheduled, and run in a shared context on the same Node.</p>
 
 			<p>Pods are the atomic unit on the Kubernetes platform. When we create a Deployment on Kubernetes, that Deployment creates Pods with containers inside them (as opposed to creating containers directly). Each Pod is tied to the Node where it is scheduled, and remains there until termination (according to restart policy) or deletion. In case of a Node failure, identical Pods are scheduled on other available Nodes in the cluster.</p>
-			
+
 			</div>
 			<div class="col-md-4">
 				<div class="content__box content__box_lined">
@@ -266,7 +269,7 @@
 					<li>Kubelet, a process responsible for communication between the Kubernetes Master and the Nodes; it manages the Pods and the containers running on a machine.</li>
 					<li>A container runtime (like Docker, rkt) responsible for pulling the container image from a registry, unpacking the container, and running the application.</li>
 				</ul>
-				
+
 			</div>
 			<div class="col-md-4">
 				<div class="content__box content__box_fill">
@@ -300,11 +303,11 @@
 					<li><b>kubectl logs</b> - print the logs from a container in a pod</li>
 					<li><b>kubectl exec</b> - execute a command on a container in a pod</li>
 				</ul>
-				
+
 				<p>You can use these commands to see when applications were deployed, what their current status is, where they are running and what their configuration is.</p>
 
 				<p>Now that we know more about our cluster components and the command line, let’s explore our application.</p>
-			
+
 			</div>
 			<div class="col-md-4">
 				<div class="content__box content__box_fill">
@@ -325,7 +328,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -367,7 +370,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/3-2.html
+++ b/3-2.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121828992">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121828992" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -45,7 +46,7 @@
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
 	<script src="https://katacoda.com/embed.js"></script>
-	
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -226,7 +229,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -268,7 +271,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/3-3-1.html
+++ b/3-3-1.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121829007">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121829007" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -184,7 +187,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -215,7 +218,7 @@
 
                 <div id="quizTest3"></div>
 
-				
+
 			</div>
 			<div class="col-md-1"></div>
 		</div>
@@ -234,7 +237,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -276,7 +279,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/3-3-2.html
+++ b/3-3-2.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1469803628265">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1469803628265" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
 	<script src="./public/js/common.js"></script>
@@ -56,7 +57,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -184,7 +187,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -210,7 +213,7 @@
 		<br>
 		<br>
 		<h2 class="title-light">Congratulations!</h2>
-		
+
 		<p style="color: #3771e3;"><i><big>You’ve completed Module 3 of the Bootcamp</big></i></p>
 
 		<br>
@@ -254,7 +257,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -296,7 +299,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/3-3.html
+++ b/3-3.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121829034">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121829034" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -185,7 +188,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -228,7 +231,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -270,7 +273,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/4-0.html
+++ b/4-0.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1469803628195">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1469803628195" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
 	<script src="./public/js/common.js"></script>
@@ -56,7 +57,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -184,7 +187,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -240,7 +243,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -282,7 +285,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/4-1.html
+++ b/4-1.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121828969">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121828969" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -185,7 +188,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -232,7 +235,7 @@
 				</div>
 				<div class="content__box content__box_fill">
 						<p><i>
-							A Kubernetes Service is an abstraction layer which defines a logical set of Pods and enables external traffic exposure, load balancing and service discovery for those Pods. 
+							A Kubernetes Service is an abstraction layer which defines a logical set of Pods and enables external traffic exposure, load balancing and service discovery for those Pods.
 						</i></p>
 				</div>
 			</div>
@@ -257,10 +260,10 @@
 
 				<p>A Service provides load balancing of traffic across the contained set of Pods. This is useful when a service is created to group all Pods from a specific Deployment (our application will make use of this in the next module, when we’ll have multiple instances running).</p>
 
-				<p>Services are also responsible for service-discovery within the cluster (covered in Module 6). This will for example allow a frontend service (like a webserver) to receive traffic from a backend service (like a database) without worrying about Pods.</p> 
+				<p>Services are also responsible for service-discovery within the cluster (covered in Module 6). This will for example allow a frontend service (like a webserver) to receive traffic from a backend service (like a database) without worrying about Pods.</p>
 
 				<p>Services match a set of Pods using Label Selectors, a grouping primitive that allows logical operation on Labels.</p>
-				
+
 			</div>
 			<div class="col-md-4">
 				<div class="content__box content__box_fill">
@@ -278,7 +281,7 @@
 					<li>Production environment (production, test, dev)</li>
 					<li>Application version (beta, v1.3)</li>
 					<li>Type of service/server (frontend, backend, database)</li>
-				</ul>	
+				</ul>
 			</div>
 			<div class="col-md-4">
 				<div class="content__box content__box_fill">
@@ -305,7 +308,7 @@
 				<p>Labels can be attached to objects at the creation time or later and can be modified at any time.
 				The kubectl run command sets some default Labels/Label Selectors on the new Pods/ Deployment. The link between Labels and Label Selectors defines the relationship between the Deployment and the Pods it creates.</p>
 
-				<p>Let’s expose now our application with the help of a Service, and apply some new Labels.</p> 
+				<p>Let’s expose now our application with the help of a Service, and apply some new Labels.</p>
 			</div>
 		</div>
 		<br>
@@ -320,7 +323,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -362,7 +365,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/4-2.html
+++ b/4-2.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121828992">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121828992" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -45,7 +46,7 @@
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
 	<script src="https://katacoda.com/embed.js"></script>
-	
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -226,7 +229,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -268,7 +271,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/4-3-1.html
+++ b/4-3-1.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121829007">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121829007" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -184,7 +187,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -215,7 +218,7 @@
 
                 <div id="quizTest4"></div>
 
-				
+
 			</div>
 			<div class="col-md-1"></div>
 		</div>
@@ -234,7 +237,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -276,7 +279,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/4-3-2.html
+++ b/4-3-2.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1469803628265">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1469803628265" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
 	<script src="./public/js/common.js"></script>
@@ -56,7 +57,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -184,7 +187,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -210,7 +213,7 @@
 		<br>
 		<br>
 		<h2 class="title-light">Congratulations!</h2>
-		
+
 		<p style="color: #3771e3;"><i><big>You’ve completed Module 4 of the Bootcamp</big></i></p>
 
 		<br>
@@ -254,7 +257,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -296,7 +299,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/4-3.html
+++ b/4-3.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121829034">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121829034" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -185,7 +188,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -228,7 +231,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -270,7 +273,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/404.html
+++ b/404.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121829105">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121829105" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -205,7 +208,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -218,7 +221,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -260,7 +263,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/5-0.html
+++ b/5-0.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1469803628195">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1469803628195" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
 	<script src="./public/js/common.js"></script>
@@ -56,7 +57,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -184,7 +187,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -221,7 +224,7 @@
 					<h3>What you need to know first</h3>
 					<p>
 						What are <a href="2-0.html">Deployments</a> <br>
-						What are <a href="4-0.html">Services</a> 
+						What are <a href="4-0.html">Services</a>
 					</p>
 				</div>
 			</div>
@@ -238,7 +241,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -280,7 +283,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/5-1.html
+++ b/5-1.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121828969">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121828969" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -186,7 +189,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -275,8 +278,8 @@
 
 				<p>Scaling up a Deployment will ensure new Pods are created and scheduled to Nodes with available resources. Scaling down will reduce the number of Pods to the new desired state. Kubernetes also supports <a href="http://kubernetes.io/docs/user-guide/horizontal-pod-autoscaling/"> autoscaling </a> of Pods, but it is outside of the scope of this tutorial. Scaling to zero is also possible, and it will terminate all Pods of the specified Deployment.</p>
 
-				<p>Running multiple instances of an application will require a way to distribute the traffic to all of them. Services have an integrated load-balancer that will distribute network traffic to all Pods of an exposed Deployment. Services will monitor continuously the running Pods using endpoints, to ensure the traffic is sent only to available Pods.</p> 
-				
+				<p>Running multiple instances of an application will require a way to distribute the traffic to all of them. Services have an integrated load-balancer that will distribute network traffic to all Pods of an exposed Deployment. Services will monitor continuously the running Pods using endpoints, to ensure the traffic is sent only to available Pods.</p>
+
 			</div>
 			<div class="col-md-4">
 				<div class="content__box content__box_fill">
@@ -289,7 +292,7 @@
 
 		<div class="row">
 			<div class="col-md-8">
-				<p> Once you have multiple instances of an Application running, you would be able to do Rolling updates without downtime. We’ll cover that in the next module. Now, let’s go to the online terminal and scale our application.</p>	
+				<p> Once you have multiple instances of an Application running, you would be able to do Rolling updates without downtime. We’ll cover that in the next module. Now, let’s go to the online terminal and scale our application.</p>
 			</div>
 		</div>
 		<br>
@@ -305,7 +308,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -347,7 +350,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/5-2.html
+++ b/5-2.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121828992">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121828992" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -45,7 +46,7 @@
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
 	<script src="https://katacoda.com/embed.js"></script>
-	
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -226,7 +229,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -268,7 +271,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/5-3-1.html
+++ b/5-3-1.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121829007">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121829007" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -184,7 +187,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -215,7 +218,7 @@
 
                 <div id="quizTest5"></div>
 
-				
+
 			</div>
 			<div class="col-md-1"></div>
 		</div>
@@ -234,7 +237,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -276,7 +279,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/5-3-2.html
+++ b/5-3-2.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1469803628265">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1469803628265" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
 	<script src="./public/js/common.js"></script>
@@ -56,7 +57,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -184,7 +187,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -210,7 +213,7 @@
 		<br>
 		<br>
 		<h2 class="title-light">Congratulations!</h2>
-		
+
 		<p style="color: #3771e3;"><i><big>You’ve completed Module 5 of the Bootcamp</big></i></p>
 
 		<br>
@@ -254,7 +257,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -296,7 +299,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/5-3.html
+++ b/5-3.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121829034">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121829034" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -185,7 +188,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -228,7 +231,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -270,7 +273,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/6-0.html
+++ b/6-0.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1469803628195">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1469803628195" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
 	<script src="./public/js/common.js"></script>
@@ -56,7 +57,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -72,7 +75,7 @@
 	</div>
 </header>
 
-		
+
 			<ul class="nav">
 				<li class="marked">
 					<a href="index.html">
@@ -186,7 +189,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -222,7 +225,7 @@
 					<h3>What you need to know first</h3>
 					<p>
 						What are <a href="2-0.html">Deployments</a> <br>
-						What is <a href="5-0.html">Scaling</a> 
+						What is <a href="5-0.html">Scaling</a>
 					</p>
 				</div>
 			</div>
@@ -239,7 +242,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -281,7 +284,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/6-1.html
+++ b/6-1.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121828969">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121828969" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -187,7 +190,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -217,7 +220,7 @@
 			<div class="col-md-8">
 			<p>Users expect applications to be available all the time and developers are expected to deploy new versions of them several times a day. In Kubernetes this is done with rolling updates. <b>Rolling updates</b> allows Deployments to occur with zero downtime by incrementally updating Pods instances with new ones. The new Pods will be scheduled on Nodes with available resources.</p>
 
-			<p>In the previous module we scaled our application to run multiple instances. This is a requirement for performing updates without affecting application availability. By default, the maximum number of Pods that can be unavailable during the update and the maximum number of new Pods that can be created, is one. Both options can be configured to either numbers or percentages (of Pods). 
+			<p>In the previous module we scaled our application to run multiple instances. This is a requirement for performing updates without affecting application availability. By default, the maximum number of Pods that can be unavailable during the update and the maximum number of new Pods that can be created, is one. Both options can be configured to either numbers or percentages (of Pods).
 			In Kubernetes, updates are versioned and any Deployment update can be reverted to a previously (stable) version.</p>
 
 
@@ -287,14 +290,14 @@
 
 				<p>Similar to application Scaling, If a Deployment is exposed publicly, the Service will load-balance the traffic only to available Pods during the update. An available Pod is an instance that is available to the users of the application.</p>
 
-				<p>Rolling updates allow the following actions:</p> 
+				<p>Rolling updates allow the following actions:</p>
 				<ul>
 					<li>Promote an application from one environment to another (via container image updates)</li>
 					<li>Rollback to previous versions</li>
 					<li>Continuous Integration and Continuous Delivery of applications with zero downtime</li>
 
 				</ul>
-				
+
 			</div>
 			<div class="col-md-4">
 				<div class="content__box content__box_fill">
@@ -307,7 +310,7 @@
 
 		<div class="row">
 			<div class="col-md-8">
-				<p> In the following interactive tutorial we’ll update our application to a new version, and also perform a rollback.</p>	
+				<p> In the following interactive tutorial we’ll update our application to a new version, and also perform a rollback.</p>
 			</div>
 		</div>
 		<br>
@@ -323,7 +326,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -365,7 +368,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/6-2.html
+++ b/6-2.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121828992">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121828992" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -45,7 +46,7 @@
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
 	<script src="https://katacoda.com/embed.js"></script>
-	
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -227,7 +230,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -269,7 +272,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/6-3-1.html
+++ b/6-3-1.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121829007">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121829007" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -185,7 +188,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -216,7 +219,7 @@
 
                 <div id="quizTest6"></div>
 
-				
+
 			</div>
 			<div class="col-md-1"></div>
 		</div>
@@ -235,7 +238,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -277,7 +280,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/6-3-2.html
+++ b/6-3-2.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1469803628265">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1469803628265" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
 	<script src="./public/js/common.js"></script>
@@ -56,7 +57,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -72,7 +75,7 @@
 	</div>
 </header>
 
-			
+
 			<ul class="nav">
 				<li class="marked">
 					<a href="index.html">
@@ -186,7 +189,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -212,7 +215,7 @@
 		<br>
 		<br>
 		<h2 class="title-light">Congratulations!</h2>
-		
+
 		<p style="color: #3771e3;"><i><big>You’ve completed Module 6 of the Bootcamp</big></i></p>
 
 		<br>
@@ -256,7 +259,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -298,7 +301,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/6-3.html
+++ b/6-3.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121829034">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121829034" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -186,7 +189,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -229,7 +232,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -271,7 +274,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/6-4.html
+++ b/6-4.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121829062">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121829062" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,9 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -186,7 +189,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -254,7 +257,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -296,7 +299,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
+# This project has been archived.
+
+This project has been merged into the central Kubernetes docs repository.
+
+Visit https://kubernetes.io/docs/tutorials/kubernetes-basics/ to view the content.
+
+Changes can be made at https://github.com/kubernetes/website/tree/master/docs/tutorials/kubernetes-basics
+
 # kubernetes-bootcamp
 This is the official kubernetes bootcamp
 
-The goal of the bootcamp content is to introduce developers/ first time users to Kubernetess. By the end of the bootcamp they will know: what Kubernetes does and how to deploy generic containerized applications on top of it. 
-They will become also familiar with main kubernetes concepts. 
+The goal of the bootcamp content is to introduce developers/ first time users to Kubernetes. By the end of the bootcamp they will know: what Kubernetes does and how to deploy generic containerized applications on top of it.
+They will become also familiar with main kubernetes concepts.
 
 The bootcamp assumes users have some knowledge of software containers (Docker, rkt, etc).
-

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Kubernetes Bootcamp</title>
+	<meta http-equiv="refresh" content="0;URL='https://kubernetes.io/docs/tutorials/kubernetes-basics/'" />
 	<meta name="description" content="K8S">
 	<meta name="keywords" content="K8S Keywords">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -25,11 +26,11 @@
 	<meta itemprop="description" content="K8S">
 	<meta itemprop="image" content="./public/uploads/soc_index.jpg">
 
-	
+
 	<link rel="manifest" href="./manifest.json?v=1470121829149">
 	<link rel="mask-icon" href="./public/images/safari-pinned-tab.svg?v=1470121829149" color="#A2B2F2">
 	<meta name="msapplication-TileColor" content="#A2B2F2">
-	
+
 	<meta name="theme-color" content="#A2B2F2">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
@@ -44,8 +45,8 @@
 
 	<!--<script src="./public/js/jquery-3.1.0.min.js"></script>-->
 	<script src="./public/js/jquery-1.12.1.min.js"></script>
-	
-	
+
+
 	<script src="./public/js/bootstrap.min.js"></script>
 	<script src="./public/js/swiper.jquery.min.js"></script>
     <script src='./public/js/ractive.js'></script>
@@ -57,7 +58,10 @@
 
 <div class="layout" id="top">
 
-	
+	<div style="position: fixed;background: #ffff94;width: 100%;z-index: 1000;text-align: center;font-size: 1.5rem;font-weight: bold;">
+		This content has moved to <a href="https://kubernetes.io/docs/tutorials/kubernetes-basics/">https://kubernetes.io/docs/tutorials/kubernetes-basics/</a>
+	</div>
+
 
 	<aside class="sidebar">
 		<div class="sidebar__inner">
@@ -286,7 +290,7 @@
 
 
 
-	
+
 
 	<main class="content">
 		<div class="content__sider">
@@ -385,7 +389,7 @@
 
 
 
-	
+
 		<!-- header start -->
 <footer class="footer" role="contentinfo">
 	<div class="footer__content">
@@ -427,7 +431,7 @@
 	</div>
 </footer>
 <!-- header finish --> <a class="scrolltop" href="#top"></a>
-	
+
 
 </div>
 


### PR DESCRIPTION
As discussed at https://github.com/kubernetes/website/issues/7506

The approach uses a HTML meta tag to redirect users. Given the site is based on GH-Pages, this was the quickest way as we couldn't configure routing rules.

I also add a notice to the README so users know where to go for content/changes/suggestions.